### PR TITLE
Treat empty node as string

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -36,6 +36,9 @@ final class Helper
 						if (!isset($output[$t])) {
 							$output[$t] = [];
 						}
+                        if (empty($v)) {
+                            $v = '';
+                        }
 						$output[$t][] = $v;
 					} elseif ($v || $v === '0') {
 						$output = (string) $v;


### PR DESCRIPTION
As the title says :) When you convert an XML with empty nodes, all the empty nodes will be output as an empty array. In my opinion and empty node rather represents an empty string. This PR makes that change.

If you have an XML as follows:
```xml
<tv>
	<show name="Family Guy">
		<dog></dog>
		<kid>Chris</kid>
		<kid>Meg</kid>
	</show>
</tv>
```

This now comes out as:
```
(
    [show] => Array
        (
            [dog] => Array
                (
                )

            [kid] => Array
                (
                    [0] => Chris
                    [1] => Meg
                )

            [@attributes] => Array
                (
                    [name] => Family Guy
                )

        )

    [@root] => tv
)
```

In my opinion it would be better to show the dog as an empty string:
```
(
    [show] => Array
        (
            [dog] => 
            [kid] => Array
                (
                    [0] => Chris
                    [1] => Meg
                )

            [@attributes] => Array
                (
                    [name] => Family Guy
                )

        )

    [@root] => tv
)
```