### PR TITLE
Convertor: Input should be normalized automatically.

### DIFF
--- a/src/Convertor.php
+++ b/src/Convertor.php
@@ -21,7 +21,7 @@ final class Convertor
 	{
 		assert(\class_exists('\DOMDocument'));
 		$doc = new \DOMDocument();
-		$doc->loadXML($xml);
+		$doc->loadXML(str_replace(["\r\n", "\r"], "\n", trim($xml)));
 		$root = $doc->documentElement;
 		$output = (array) Helper::domNodeToArray($root);
 		$output['@root'] = $root->tagName;


### PR DESCRIPTION
In case of broken string or XML starting with empty line this logic can fix it.